### PR TITLE
修正: QRコード画面で詩が表示されない問題を解決

### DIFF
--- a/src/features/talkart/supabaseArtStorage.ts
+++ b/src/features/talkart/supabaseArtStorage.ts
@@ -209,6 +209,19 @@ export class SupabaseArtStorage {
         data.image_url = getPublicUrl(data.image_url)
       }
 
+      // Extract poetry from responses array if available
+      if (data && data.responses && Array.isArray(data.responses)) {
+        const poetryResponse = data.responses.find(
+          (r: any) => r.type === 'poetry'
+        )
+        if (poetryResponse) {
+          data.poetry = {
+            poem: poetryResponse.content,
+            metadata: poetryResponse.metadata || {},
+          }
+        }
+      }
+
       return data
     } catch (error) {
       console.error('Failed to get artwork:', error)
@@ -240,6 +253,19 @@ export class SupabaseArtStorage {
       // Get full image URL
       if (data && data.image_url) {
         data.image_url = getPublicUrl(data.image_url)
+      }
+
+      // Extract poetry from responses array if available
+      if (data && data.responses && Array.isArray(data.responses)) {
+        const poetryResponse = data.responses.find(
+          (r: any) => r.type === 'poetry'
+        )
+        if (poetryResponse) {
+          data.poetry = {
+            poem: poetryResponse.content,
+            metadata: poetryResponse.metadata || {},
+          }
+        }
       }
 
       // Increment view count


### PR DESCRIPTION
問題: データベースのresponses配列から詩データを抽出していなかった
修正:
- getArtworkメソッドにresponses配列から詩データを抽出する処理を追加
- getArtworkByShareCodeメソッドにも同様の処理を追加
- type: 'poetry'のレスポンスからpoem内容をpoetryフィールドに設定

これでQRコード画面でも詩付きの合成画像が表示されるようになる

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Artworks now include associated poetry when available, displayed alongside the image across artwork detail, share, and recent views.
  * Recent artworks now show richer generation details (e.g., question mode, style, themes, creation time, session) for added context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->